### PR TITLE
Enhance PLN screens with green styling and icons

### DIFF
--- a/app/pln/cuenta.tsx
+++ b/app/pln/cuenta.tsx
@@ -1,14 +1,45 @@
 import { View, Text, StyleSheet } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+
+const GREEN = '#2e7d32';
 
 export default function CuentaRegresiva() {
   return (
     <View style={styles.container}>
-      <Text style={styles.time}>12:34</Text>
+      <View style={styles.header}>
+        <Ionicons name="leaf-outline" size={24} color={GREEN} />
+        <Text style={styles.headerTitle}>PLN</Text>
+      </View>
+      <View style={styles.card}>
+        <Ionicons name="time-outline" size={32} color={GREEN} />
+        <Text style={styles.time}>12 días restantes</Text>
+      </View>
     </View>
   );
 }
 
 const styles = StyleSheet.create({
-  container: { flex: 1, justifyContent: 'center', alignItems: 'center' },
-  time: { fontSize: 48, fontWeight: 'bold' },
+  container: {
+    flex: 1,
+    padding: 20,
+    alignItems: 'center',
+    justifyContent: 'flex-start',
+    backgroundColor: '#fff',
+  },
+  header: { flexDirection: 'row', alignItems: 'center', marginBottom: 20 },
+  headerTitle: { fontSize: 20, fontWeight: 'bold', marginLeft: 8, color: GREEN },
+  card: {
+    borderWidth: 1,
+    borderColor: GREEN,
+    padding: 20,
+    borderRadius: 8,
+    shadowColor: '#000',
+    shadowOpacity: 0.1,
+    shadowOffset: { width: 0, height: 2 },
+    shadowRadius: 4,
+    elevation: 3,
+    alignItems: 'center',
+    width: '100%',
+  },
+  time: { fontSize: 32, fontWeight: 'bold', color: GREEN, marginTop: 10 },
 });

--- a/app/pln/index.tsx
+++ b/app/pln/index.tsx
@@ -1,18 +1,39 @@
 import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
 import { Link } from 'expo-router';
+import { Ionicons } from '@expo/vector-icons';
+
+const GREEN = '#2e7d32';
 
 export default function PLNFrase() {
   return (
     <View style={styles.container}>
-      <Text style={styles.text}>“Trabajando juntos por el futuro”</Text>
+      <View style={styles.header}>
+        <Ionicons name="leaf-outline" size={24} color={GREEN} />
+        <Text style={styles.headerTitle}>PLN</Text>
+      </View>
+      <View style={styles.card}>
+        <Text style={styles.text}>“Trabajando juntos por el futuro”</Text>
+      </View>
       <Link href="/pln/cuenta" asChild>
         <TouchableOpacity style={styles.button}>
-          <Text>Cuenta regresiva</Text>
+          <Ionicons
+            name="time-outline"
+            size={20}
+            color="#fff"
+            style={styles.buttonIcon}
+          />
+          <Text style={styles.buttonText}>Cuenta regresiva</Text>
         </TouchableOpacity>
       </Link>
       <Link href="/pln/meta" asChild>
         <TouchableOpacity style={styles.button}>
-          <Text>Meta</Text>
+          <Ionicons
+            name="flag-outline"
+            size={20}
+            color="#fff"
+            style={styles.buttonIcon}
+          />
+          <Text style={styles.buttonText}>Meta</Text>
         </TouchableOpacity>
       </Link>
     </View>
@@ -20,7 +41,39 @@ export default function PLNFrase() {
 }
 
 const styles = StyleSheet.create({
-  container: { flex: 1, justifyContent: 'center', alignItems: 'center', padding: 20 },
-  text: { fontSize: 18, marginBottom: 20, textAlign: 'center' },
-  button: { backgroundColor: '#ddd', padding: 10, marginTop: 10 },
+  container: {
+    flex: 1,
+    justifyContent: 'flex-start',
+    alignItems: 'center',
+    padding: 20,
+    backgroundColor: '#fff',
+  },
+  header: { flexDirection: 'row', alignItems: 'center', marginBottom: 20 },
+  headerTitle: { fontSize: 20, fontWeight: 'bold', marginLeft: 8, color: GREEN },
+  card: {
+    borderWidth: 1,
+    borderColor: GREEN,
+    padding: 20,
+    borderRadius: 8,
+    shadowColor: '#000',
+    shadowOpacity: 0.1,
+    shadowOffset: { width: 0, height: 2 },
+    shadowRadius: 4,
+    elevation: 3,
+    marginBottom: 20,
+    width: '100%',
+  },
+  text: { fontSize: 18, textAlign: 'center', color: GREEN },
+  button: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: GREEN,
+    padding: 12,
+    borderRadius: 6,
+    marginTop: 10,
+    width: '100%',
+  },
+  buttonText: { color: '#fff', fontWeight: 'bold', marginLeft: 6 },
+  buttonIcon: { marginRight: 6 },
 });

--- a/app/pln/meta.tsx
+++ b/app/pln/meta.tsx
@@ -1,14 +1,52 @@
 import { View, Text, StyleSheet } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+
+const GREEN = '#2e7d32';
 
 export default function Meta() {
   return (
     <View style={styles.container}>
-      <Text style={styles.text}>75% 376/500</Text>
+      <View style={styles.header}>
+        <Ionicons name="leaf-outline" size={24} color={GREEN} />
+        <Text style={styles.headerTitle}>PLN</Text>
+      </View>
+      <View style={styles.card}>
+        <Ionicons name="flag-outline" size={32} color={GREEN} />
+        <Text style={styles.percentage}>75%</Text>
+        <Text style={styles.progress}>376/500</Text>
+      </View>
     </View>
   );
 }
 
 const styles = StyleSheet.create({
-  container: { flex: 1, justifyContent: 'center', alignItems: 'center' },
-  text: { fontSize: 24, fontWeight: 'bold' },
+  container: {
+    flex: 1,
+    padding: 20,
+    alignItems: 'center',
+    justifyContent: 'flex-start',
+    backgroundColor: '#fff',
+  },
+  header: { flexDirection: 'row', alignItems: 'center', marginBottom: 20 },
+  headerTitle: { fontSize: 20, fontWeight: 'bold', marginLeft: 8, color: GREEN },
+  card: {
+    borderWidth: 1,
+    borderColor: GREEN,
+    padding: 20,
+    borderRadius: 8,
+    shadowColor: '#000',
+    shadowOpacity: 0.1,
+    shadowOffset: { width: 0, height: 2 },
+    shadowRadius: 4,
+    elevation: 3,
+    alignItems: 'center',
+    width: '100%',
+  },
+  percentage: {
+    fontSize: 32,
+    fontWeight: 'bold',
+    color: GREEN,
+    marginTop: 10,
+  },
+  progress: { fontSize: 16, color: GREEN, marginTop: 4 },
 });


### PR DESCRIPTION
## Summary
- Add green-themed header with leaf logo to PLN screens
- Display quotes, countdown, and goal inside bordered cards with subtle shadows
- Style action buttons, percentages, and countdown text in prominent green with Ionicons icons

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a8e698f1fc8331ae612ddd462a9388