### PR TITLE
Improve Social feed styling and poll selection

### DIFF
--- a/app/social/encuesta.tsx
+++ b/app/social/encuesta.tsx
@@ -4,21 +4,17 @@ import { useState } from 'react';
 const opciones = ['Opción A', 'Opción B', 'Opción C'];
 
 export default function Encuesta() {
-  const [enviada, setEnviada] = useState(false);
-
-  if (enviada) {
-    return (
-      <View style={styles.container}>
-        <Text>Respuesta enviada</Text>
-      </View>
-    );
-  }
+  const [seleccion, setSeleccion] = useState<string | null>(null);
 
   return (
     <View style={styles.container}>
       {opciones.map((o) => (
-        <TouchableOpacity key={o} style={styles.button} onPress={() => setEnviada(true)}>
-          <Text>{o}</Text>
+        <TouchableOpacity
+          key={o}
+          style={[styles.button, seleccion === o && styles.selected]}
+          onPress={() => setSeleccion(o)}
+        >
+          <Text style={styles.buttonText}>{o}</Text>
         </TouchableOpacity>
       ))}
     </View>
@@ -27,5 +23,14 @@ export default function Encuesta() {
 
 const styles = StyleSheet.create({
   container: { flex: 1, justifyContent: 'center', alignItems: 'center', padding: 20 },
-  button: { padding: 12, backgroundColor: '#ddd', marginVertical: 8, width: '80%', alignItems: 'center' },
+  button: {
+    padding: 12,
+    backgroundColor: '#E8F5E9',
+    marginVertical: 8,
+    width: '80%',
+    alignItems: 'center',
+    borderRadius: 6,
+  },
+  selected: { backgroundColor: '#C8E6C9' },
+  buttonText: { color: '#2e7d32' },
 });

--- a/app/social/index.tsx
+++ b/app/social/index.tsx
@@ -1,18 +1,62 @@
-import { View, Text, StyleSheet, ScrollView, TouchableOpacity } from 'react-native';
+import { View, Text, StyleSheet, ScrollView, TouchableOpacity, Image } from 'react-native';
 import { Link } from 'expo-router';
+import Ionicons from '@expo/vector-icons/Ionicons';
 
 const posts = [
-  { id: 1, text: 'Primer post', likes: 3, comments: 1 },
-  { id: 2, text: 'Segundo post', likes: 5, comments: 2 },
+  {
+    id: 1,
+    avatar: 'https://i.pravatar.cc/100?img=1',
+    name: 'Ana',
+    time: 'Hace 2h',
+    text: 'Disfrutando el día #feliz #verde',
+    likes: 3,
+    comments: 1,
+  },
+  {
+    id: 2,
+    avatar: 'https://i.pravatar.cc/100?img=2',
+    name: 'Luis',
+    time: 'Hace 5h',
+    text: 'Segundo post con #expo',
+    likes: 5,
+    comments: 2,
+  },
 ];
+
+const renderTextWithHashtags = (text: string) =>
+  text.split(/(#[^\s#]+)/g).map((part, index) =>
+    part.startsWith('#') ? (
+      <Text key={index} style={styles.hashtag}>
+        {part}
+      </Text>
+    ) : (
+      part
+    ),
+  );
 
 export default function Feed() {
   return (
     <ScrollView contentContainerStyle={styles.container}>
       {posts.map((p) => (
         <View key={p.id} style={styles.card}>
-          <Text>{p.text}</Text>
-          <Text>{p.likes} likes, {p.comments} comentarios</Text>
+          <View style={styles.header}>
+            <Image source={{ uri: p.avatar }} style={styles.avatar} />
+            <View>
+              <Text style={styles.name}>{p.name}</Text>
+              <Text style={styles.time}>{p.time}</Text>
+            </View>
+          </View>
+          <Text style={styles.postText}>{renderTextWithHashtags(p.text)}</Text>
+          <View style={styles.counts}>
+            <View style={styles.countItem}>
+              <Ionicons name="heart" size={16} color="#2e7d32" />
+              <Text style={styles.countText}>{p.likes}</Text>
+            </View>
+            <View style={styles.countItem}>
+              <Ionicons name="chatbubble" size={16} color="#2e7d32" />
+              <Text style={styles.countText}>{p.comments}</Text>
+            </View>
+          </View>
         </View>
       ))}
       <Link href="/social/encuesta" asChild>
@@ -31,6 +75,22 @@ export default function Feed() {
 
 const styles = StyleSheet.create({
   container: { padding: 20 },
-  card: { padding: 12, backgroundColor: '#eee', marginBottom: 10 },
+  card: {
+    padding: 12,
+    backgroundColor: '#fff',
+    borderWidth: 1,
+    borderColor: '#a5d6a7',
+    borderRadius: 8,
+    marginBottom: 10,
+  },
+  header: { flexDirection: 'row', alignItems: 'center', marginBottom: 8 },
+  avatar: { width: 40, height: 40, borderRadius: 20, marginRight: 8 },
+  name: { color: '#2e7d32', fontWeight: 'bold' },
+  time: { color: '#777' },
+  postText: { color: '#000', marginBottom: 8 },
+  hashtag: { color: '#2e7d32' },
+  counts: { flexDirection: 'row' },
+  countItem: { flexDirection: 'row', alignItems: 'center', marginRight: 16 },
+  countText: { marginLeft: 4, color: '#2e7d32' },
   button: { marginTop: 10, padding: 12, backgroundColor: '#ddd', alignItems: 'center' },
 });


### PR DESCRIPTION
## Summary
- Style Social feed posts with green-accent cards, avatars, and counters
- Highlight hashtags and add like/comment icons
- Add selectable light-green poll buttons

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a8e7c164e883318f43b8e0ef266c54