### PR TITLE
feat: add App entry for Expo Snack

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,0 +1,6 @@
+import { ExpoRoot } from 'expo-router';
+
+export default function App() {
+  const ctx = (require as any).context('./app');
+  return <ExpoRoot context={ctx} />;
+}

--- a/README.md
+++ b/README.md
@@ -48,3 +48,13 @@ Join our community of developers creating universal apps.
 
 - [Expo on GitHub](https://github.com/expo/expo): View our open source platform and contribute.
 - [Discord community](https://chat.expo.dev): Chat with Expo users and ask questions.
+
+## Run in Expo Snack
+
+To preview this project in [Expo Snack](https://snack.expo.dev/):
+
+1. Copy the `App.tsx` file and the entire `app` directory into a new Snack.
+2. Use Snack's **Add Dependency** option to include the packages listed in `package.json`.
+
+Alternatively, you can import this repository directly in Snack by selecting **Import GitHub** and providing the repo URL.
+


### PR DESCRIPTION
## Summary
- add `App.tsx` root component compatible with Expo Snack
- document how to preview the project in Expo Snack

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a918f69b2c8331b01d943d09c2e593