### PR TITLE
fix: remove require.context from App entry

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,6 +1,6 @@
-import { ExpoRoot } from 'expo-router';
-
-export default function App() {
-  const ctx = (require as any).context('./app');
-  return <ExpoRoot context={ctx} />;
-}
+// The Expo Router automatically registers all routes from the `app` directory.
+// Using the built-in `expo-router/entry` removes the need for `require.context`,
+// which isn't available in the Metro bundler used by Expo.
+// Exporting the default entry resolves runtime errors where `require.context`
+// is undefined.
+export { default } from 'expo-router/entry';


### PR DESCRIPTION
## Summary
- replace custom App entry with expo-router's default to avoid require.context errors

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a91bcd80e483318fcbb6598091ff61