### PR TITLE
docs: clarify snack setup and add expo-router types

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Join our community of developers creating universal apps.
 
 To preview this project in [Expo Snack](https://snack.expo.dev/):
 
-1. Copy the `App.tsx` file and the entire `app` directory into a new Snack.
+1. Copy the `App.tsx` file, the entire `app` directory, and any `.d.ts` declaration files (e.g. `expo-linear-gradient.d.ts`, `expo-router-entry.d.ts`) into a new Snack.
 2. Use Snack's **Add Dependency** option to include the packages listed in `package.json`.
 
 Alternatively, you can import this repository directly in Snack by selecting **Import GitHub** and providing the repo URL.

--- a/expo-router-entry.d.ts
+++ b/expo-router-entry.d.ts
@@ -1,0 +1,1 @@
+declare module 'expo-router/entry';


### PR DESCRIPTION
## Summary
- add module declaration for expo-router entry
- document copying of d.ts files when using Expo Snack

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: expo: not found)
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68a9224eba088331a85610ab6195d5b0