### PR TITLE
Fix tab routes for index pages

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -3,10 +3,10 @@ import { Tabs } from 'expo-router';
 export default function RootLayout() {
   return (
     <Tabs>
-      <Tabs.Screen name="censos" options={{ title: 'Censos' }} />
+      <Tabs.Screen name="censos/index" options={{ title: 'Censos' }} />
       <Tabs.Screen name="miEquipo" options={{ title: 'MiEquipo' }} />
-      <Tabs.Screen name="pln" options={{ title: 'PLN' }} />
-      <Tabs.Screen name="social" options={{ title: 'Social' }} />
+      <Tabs.Screen name="pln/index" options={{ title: 'PLN' }} />
+      <Tabs.Screen name="social/index" options={{ title: 'Social' }} />
       <Tabs.Screen name="perfil" options={{ title: 'Perfil' }} />
     </Tabs>
   );


### PR DESCRIPTION
## Summary
- link tab screens to their index routes so content renders

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a92523f73883319e4c34994a4f4775