### PR TITLE
Add default tab redirection for Expo router

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -2,11 +2,11 @@ import { Tabs } from 'expo-router';
 
 export default function RootLayout() {
   return (
-    <Tabs>
-      <Tabs.Screen name="censos/index" options={{ title: 'Censos' }} />
+    <Tabs initialRouteName="censos">
+      <Tabs.Screen name="censos" options={{ title: 'Censos' }} />
       <Tabs.Screen name="miEquipo" options={{ title: 'MiEquipo' }} />
-      <Tabs.Screen name="pln/index" options={{ title: 'PLN' }} />
-      <Tabs.Screen name="social/index" options={{ title: 'Social' }} />
+      <Tabs.Screen name="pln" options={{ title: 'PLN' }} />
+      <Tabs.Screen name="social" options={{ title: 'Social' }} />
       <Tabs.Screen name="perfil" options={{ title: 'Perfil' }} />
     </Tabs>
   );

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -1,0 +1,5 @@
+import { Redirect } from 'expo-router';
+
+export default function Index() {
+  return <Redirect href="/censos" />;
+}


### PR DESCRIPTION
## Summary
- set tab routes at the top level and default to `censos`
- add index route that redirects to `censos`

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a927539c5c8331a9e2ab274e0797d6