### PR TITLE
chore: improve Snack compatibility

### DIFF
--- a/App.js
+++ b/App.js
@@ -1,0 +1,1 @@
+export { default } from './App';

--- a/README.md
+++ b/README.md
@@ -52,9 +52,9 @@ Join our community of developers creating universal apps.
 ## Run in Expo Snack
 
 To preview this project in [Expo Snack](https://snack.expo.dev/):
-
-1. Copy the `App.tsx` file, the entire `app` directory, and any `.d.ts` declaration files (e.g. `expo-linear-gradient.d.ts`, `expo-router-entry.d.ts`) into a new Snack.
-2. Use Snack's **Add Dependency** option to include the packages listed in `package.json`.
+1. Snack expects an `App.js` entry file. This repository includes a small `App.js` that re-exports the TypeScript entry so the app loads correctly.
+2. Copy `App.js`, `App.tsx`, the entire `app` directory, and any `.d.ts` declaration files (e.g. `expo-linear-gradient.d.ts`, `expo-router-entry.d.ts`) into a new Snack.
+3. Use Snack's **Add Dependency** option to include the packages listed in `package.json`.
 
 Alternatively, you can import this repository directly in Snack by selecting **Import GitHub** and providing the repo URL.
 

--- a/app/components/GradientButton.tsx
+++ b/app/components/GradientButton.tsx
@@ -1,5 +1,5 @@
 import { TouchableOpacity, Text, StyleSheet, ViewStyle } from 'react-native';
-import { LinearGradient } from 'expo-linear-gradient'; // eslint-disable-line import/no-unresolved
+import { LinearGradient } from 'expo-linear-gradient';
 
 interface Props {
   title: string;


### PR DESCRIPTION
## Summary
- remove unused ESLint override from GradientButton
- document Snack usage and include App.js entry point

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a95deb0f6c8331a96cba0b8780d2de